### PR TITLE
Update Nissan Maxima generations: fix first generation model code and add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Nissan Maxima
 
+This repository contains signal set configurations for the Nissan Maxima, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Nissan Maxima.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,10 +1,13 @@
+references:
+  - "https://en.wikipedia.org/wiki/Nissan_Maxima"
+
 generations:
-  - name: "First Generation (PU11)"
+  - name: "First Generation (G910)"
     start_year: 1981
     end_year: 1984
     description: "The original Maxima wasn't yet a separate model but a trim level of the Datsun 810 (later badged as the Nissan 810 Maxima), featuring a 2.4L inline-six engine. This generation established the model's focus on being a sporty alternative to mainstream family sedans."
 
-  - name: "Second Generation (PU11)"
+  - name: "Second Generation (U11)"
     start_year: 1985
     end_year: 1988
     description: "The first standalone Maxima model, featuring front-wheel drive and powered by a 3.0L V6 engine. Available in sedan and wagon body styles, it emphasized technology with a digital instrument cluster, optional electronic adjustable suspension, and a talking voice warning system. This generation established the Maxima's position as Nissan's flagship sedan in North America, offering a combination of performance, luxury, and technology."


### PR DESCRIPTION
- Corrected first generation model code from PU11 to G910 (accurate per Wikipedia)
- Updated second generation model code from PU11 to U11 (matches Wikipedia designation)
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template for documentation

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
